### PR TITLE
Change Form to Query for transaction list

### DIFF
--- a/examples/list_transactions.rs
+++ b/examples/list_transactions.rs
@@ -1,0 +1,30 @@
+use clap::Clap;
+use monzo::Client;
+use chrono::{Duration, Utc};
+
+#[derive(Clap)]
+struct Args {
+    access_token: String,
+}
+
+#[tokio::main]
+async fn main() -> monzo::Result<()> {
+    let args = Args::parse();
+    let client = Client::new(args.access_token);
+
+    let accounts = client.accounts().await?;
+    let account_id = &accounts[0].id;
+
+    let transactions = client
+        .transactions(account_id)
+        .since(Utc::now() - Duration::days(89))
+        .limit(2)
+        .send()
+        .await?;
+
+    println!("account: {}", account_id);
+    transactions.iter()
+        .for_each(|t| println!("\t{}", t.id));
+
+    Ok(())
+}

--- a/examples/list_transactions.rs
+++ b/examples/list_transactions.rs
@@ -1,6 +1,6 @@
+use chrono::{Duration, Utc};
 use clap::Clap;
 use monzo::Client;
-use chrono::{Duration, Utc};
 
 #[derive(Clap)]
 struct Args {
@@ -23,8 +23,7 @@ async fn main() -> monzo::Result<()> {
         .await?;
 
     println!("account: {}", account_id);
-    transactions.iter()
-        .for_each(|t| println!("\t{}", t.id));
+    transactions.iter().for_each(|t| println!("\t{}", t.id));
 
     Ok(())
 }

--- a/examples/list_transactions.rs
+++ b/examples/list_transactions.rs
@@ -5,6 +5,10 @@ use monzo::Client;
 #[derive(Clap)]
 struct Args {
     access_token: String,
+    #[clap(long, default_value = "2")]
+    limit: u16,
+    #[clap(long, default_value = "89")]
+    days: i64,
 }
 
 #[tokio::main]
@@ -17,8 +21,8 @@ async fn main() -> monzo::Result<()> {
 
     let transactions = client
         .transactions(account_id)
-        .since(Utc::now() - Duration::days(89))
-        .limit(2)
+        .since(Utc::now() - Duration::days(args.days))
+        .limit(args.limit)
         .send()
         .await?;
 

--- a/src/endpoints/transactions/list.rs
+++ b/src/endpoints/transactions/list.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug)]
 pub struct Request<'a> {
     client: &'a dyn client::Inner,
-    form: Form<'a>,
+    query: Query<'a>,
 }
 
 impl<'a> Endpoint for Request<'a> {
@@ -25,25 +25,25 @@ impl<'a> Endpoint for Request<'a> {
         "https://api.monzo.com/transactions"
     }
 
-    fn form(&self) -> Option<&dyn erased_serde::Serialize> {
-        Some(&self.form)
+    fn query(&self) -> Option<&dyn erased_serde::Serialize> {
+        Some(&self.query)
     }
 }
 
 impl<'a> Request<'a> {
     pub(crate) fn new(client: &'a dyn client::Inner, account_id: &'a str) -> Self {
-        let form = Form {
+        let query = Query {
             account_id,
             pagination: Pagination::default(),
             expand_merchant: None,
         };
 
-        Self { client, form }
+        Self { client, query }
     }
 
     /// Only return transactions which occurred after the given `DateTime`
     pub fn since(mut self, datetime: DateTime<Utc>) -> Self {
-        self.form.pagination.since = Some(Since::Timestamp(datetime));
+        self.query.pagination.since = Some(Since::Timestamp(datetime));
         self
     }
 
@@ -51,26 +51,26 @@ impl<'a> Request<'a> {
     ///
     /// This can be used for paginating.
     pub fn since_transaction(mut self, transaction_id: String) -> Self {
-        self.form.pagination.since = Some(Since::ObjectId(transaction_id));
+        self.query.pagination.since = Some(Since::ObjectId(transaction_id));
         self
     }
 
     /// Only return transactions which occurred before a given `DateTime`
     pub fn before(mut self, datetime: DateTime<Utc>) -> Self {
-        self.form.pagination.before = Some(datetime);
+        self.query.pagination.before = Some(datetime);
         self
     }
 
     /// Set the maximum number of transactions to be returned
     pub fn limit(mut self, limit: u16) -> Self {
-        self.form.pagination.limit = Some(limit);
+        self.query.pagination.limit = Some(limit);
         self
     }
 
     /// Optionally expand the merchant field from an id string into a struct
     /// container merchant details
     pub fn expand_merchant(mut self) -> Self {
-        self.form.expand_merchant = Some("merchant");
+        self.query.expand_merchant = Some("merchant");
         self
     }
 
@@ -87,7 +87,7 @@ impl<'a> Request<'a> {
 }
 
 #[derive(Serialize, Debug)]
-struct Form<'a> {
+struct Query<'a> {
     account_id: &'a str,
 
     #[serde(flatten)]


### PR DESCRIPTION
The transactions endpoint expects an `account_id` query parameter, which is not currently supplied.
This PR replaces the current form implementation with query parameters.

Attempts to address #13.