### PR TITLE
Export accounts::Type as AccountType

### DIFF
--- a/src/endpoints/accounts.rs
+++ b/src/endpoints/accounts.rs
@@ -73,7 +73,7 @@ pub enum Type {
     UkBusiness,
 }
 
-pub use list::Request as List;
+pub(crate) use list::Request as List;
 mod list {
 
     use crate::endpoints::Endpoint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ mod client;
 pub use client::Client;
 mod endpoints;
 pub use endpoints::{
-    accounts::{Account, Owner},
+    accounts::{Account, Owner, Type as AccountType},
     balance::Balance,
     feed_items,
     pots::Pot,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,9 +52,10 @@ mod client;
 #[doc(inline)]
 pub use client::Client;
 mod endpoints;
+#[doc(inline)]
+pub use endpoints::accounts::{Account, Owner};
 pub use endpoints::{
     accounts,
-    accounts::{Account, Owner},
     balance::Balance,
     feed_items,
     pots::Pot,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,8 @@ mod client;
 pub use client::Client;
 mod endpoints;
 pub use endpoints::{
-    accounts::{Account, Owner, Type as AccountType},
+    accounts,
+    accounts::{Account, Owner},
     balance::Balance,
     feed_items,
     pots::Pot,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,12 +55,7 @@ mod endpoints;
 #[doc(inline)]
 pub use endpoints::accounts::{Account, Owner};
 pub use endpoints::{
-    accounts,
-    balance::Balance,
-    feed_items,
-    pots::Pot,
-    transactions,
-    transactions::Transaction,
+    accounts, balance::Balance, feed_items, pots::Pot, transactions, transactions::Transaction,
     who_am_i::Response as WhoAmI,
 };
 mod error;


### PR DESCRIPTION
Currently `accounts::Type` is not exported so you can't make use of the `account_type` field on `Account`.