### PR TITLE
feat!: use 'IntoFuture' trait to await futures directly without calling 'send'

### DIFF
--- a/examples/list_transactions.rs
+++ b/examples/list_transactions.rs
@@ -23,7 +23,6 @@ async fn main() -> monzo::Result<()> {
         .transactions(account_id)
         .since(Utc::now() - Duration::try_days(args.days).unwrap())
         .limit(args.limit)
-        .send()
         .await?;
 
     println!("account: {account_id}");

--- a/src/client.rs
+++ b/src/client.rs
@@ -183,7 +183,6 @@ where
     /// client
     ///     .basic_feed_item(account_id, title, image_url)
     ///     .body("i figured out how to send messages to monzo from my computer...")
-    ///     .send()
     ///     .await?;
     /// #
     /// # Ok(())
@@ -242,7 +241,6 @@ where
     ///     .transactions(account_id)
     ///     .since(Utc::now() - Duration::days(10))
     ///     .limit(10)
-    ///     .send()
     ///     .await?;
     /// #
     /// # Ok(())
@@ -269,7 +267,7 @@ where
     /// #
     /// let transaction_id = "TRANSACTION_ID";
     ///
-    /// let transactions = client.transaction(transaction_id).send().await?;
+    /// let transactions = client.transaction(transaction_id).await?;
     /// #
     /// # Ok(())
     /// # }

--- a/src/endpoints/transactions/get.rs
+++ b/src/endpoints/transactions/get.rs
@@ -1,3 +1,5 @@
+use std::future::{Future, IntoFuture};
+
 use super::Transaction;
 use crate::{client, endpoints::Endpoint, Result};
 
@@ -53,9 +55,18 @@ where
         self.expand_merchant = true;
         self
     }
+}
+
+impl<'a, C> IntoFuture for Request<'a, C>
+where
+    C: client::Inner,
+{
+    type Output = Result<Transaction>;
+
+    type IntoFuture = impl Future<Output = Self::Output>;
 
     /// Consume the request and return the [`Transaction`]
-    pub async fn send(self) -> Result<Transaction> {
-        self.client.handle_request(&self).await
+    fn into_future(self) -> Self::IntoFuture {
+        async move { self.client.handle_request(&self).await }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 #![warn(clippy::pedantic)]
 #![allow(clippy::missing_errors_doc)]
+#![feature(impl_trait_in_assoc_type)]
 
 //! A Monzo client in pure rust.
 //!


### PR DESCRIPTION
this works now, but shouldn't be merged until the nightly features used in it are stabilised