### PR TITLE
Add transaction decline reason 'Authentication rejected by cardholder'

### DIFF
--- a/src/endpoints/transactions.rs
+++ b/src/endpoints/transactions.rs
@@ -105,6 +105,9 @@ pub enum DeclineReason {
     /// Requires SCA
     StrongCustomerAuthenticationRequired,
 
+    /// Transaction declined by the cardholder
+    AuthenticationRejectedByCardholder,
+
     /// All other errors
     Other,
 }
@@ -348,6 +351,12 @@ mod tests {
         "##;
 
         serde_json::from_str::<Transaction>(raw).expect("couldn't decode Transaction from json");
+
+        let new = raw.replace(
+            "SCA_NOT_AUTHENTICATED_CARD_NOT_PRESENT",
+            "AUTHENTICATION_REJECTED_BY_CARDHOLDER",
+        );
+        serde_json::from_str::<Transaction>(&new).expect("couldn't decode Transaction from json");
     }
 
     #[test]


### PR DESCRIPTION
Before this change, I was getting the following on a transaction:
```
Error: Serde(Error("unknown variant `AUTHENTICATION_REJECTED_BY_CARDHOLDER`, expected one of `INSUFFICIENT_FUNDS`, `CARD_INACTIVE`, `CARD_BLOCKED`, `INVALID_CVC`, `SCA_NOT_AUTHENTICATED_CARD_NOT_PRESENT`, `STRONG_CUSTOMER_AUTHENTICATION_REQUIRED`, `OTHER`", line: 1, column: 28437))
```