### PR TITLE
fix: add missing transaction decline reason (#205)

### DIFF
--- a/src/endpoints/transactions.rs
+++ b/src/endpoints/transactions.rs
@@ -112,6 +112,9 @@ pub enum DeclineReason {
     /// Transaction declined because verifcation failed
     AuthenticationVerificationFailed,
 
+    /// Transaction declined by the decisioning engine
+    DecisioningEngineHardDecline,
+
     /// All other errors
     Other,
 }
@@ -365,6 +368,12 @@ mod tests {
         let new = raw.replace(
             "AUTHENTICATION_REJECTED_BY_CARDHOLDER",
             "AUTHENTICATION_VERIFICATION_FAILED",
+        );
+        serde_json::from_str::<Transaction>(&new).expect("couldn't decode Transaction from json");
+
+        let new = raw.replace(
+            "AUTHENTICATION_VERIFICATION_FAILED",
+            "DECISIONING_ENGINE_HARD_DECLINE",
         );
         serde_json::from_str::<Transaction>(&new).expect("couldn't decode Transaction from json");
     }

--- a/src/endpoints/transactions.rs
+++ b/src/endpoints/transactions.rs
@@ -97,6 +97,9 @@ pub enum DeclineReason {
     /// The monzo card has been blocked
     CardBlocked,
 
+    /// The monzo card has been closed
+    CardClosed,
+
     /// Incorrect CVC code used
     InvalidCvc,
 
@@ -375,6 +378,9 @@ mod tests {
             "AUTHENTICATION_VERIFICATION_FAILED",
             "DECISIONING_ENGINE_HARD_DECLINE",
         );
+        serde_json::from_str::<Transaction>(&new).expect("couldn't decode Transaction from json");
+
+        let new = raw.replace("DECISIONING_ENGINE_HARD_DECLINE", "CARD_CLOSED");
         serde_json::from_str::<Transaction>(&new).expect("couldn't decode Transaction from json");
     }
 


### PR DESCRIPTION
Add the missing transaction decline reasons "DECISIONING_ENGINE_HARD_DECLINE" and "CARD_CLOSED" which I encountered in the wild.

I think the first one refers to the situation where some internal system thinks the transaction is suspicious, and stops it (I was buying something online from another country and it asked me to verify it was really me)

Fixes #205