### PR TITLE
test: cover pot request construction

### DIFF
--- a/src/endpoints/pots/deposit.rs
+++ b/src/endpoints/pots/deposit.rs
@@ -47,3 +47,24 @@ struct Form<'a> {
     amount: u32,
     dedupe_id: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Request;
+    use crate::endpoints::Endpoint;
+
+    #[test]
+    fn builds_request() {
+        let request = Request::new("pot_1234", "account_1234", 1_000);
+
+        assert_eq!(request.endpoint(), "/pots/pot_1234/deposit");
+        assert_eq!(request.form.source_account_id, "account_1234");
+        assert_eq!(request.form.amount, 1_000);
+        assert_eq!(request.form.dedupe_id.len(), 10);
+        assert!(request
+            .form
+            .dedupe_id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric()));
+    }
+}

--- a/src/endpoints/pots/withdraw.rs
+++ b/src/endpoints/pots/withdraw.rs
@@ -47,3 +47,24 @@ struct Form<'a> {
     amount: u32,
     dedupe_id: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Request;
+    use crate::endpoints::Endpoint;
+
+    #[test]
+    fn builds_request() {
+        let request = Request::new("pot_1234", "account_1234", 1_000);
+
+        assert_eq!(request.endpoint(), "/pots/pot_1234/withdraw");
+        assert_eq!(request.form.destination_account_id, "account_1234");
+        assert_eq!(request.form.amount, 1_000);
+        assert_eq!(request.form.dedupe_id.len(), 10);
+        assert!(request
+            .form
+            .dedupe_id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric()));
+    }
+}


### PR DESCRIPTION
## Summary

- add focused tests for deposit and withdrawal request construction
- verify endpoint paths, account IDs, amounts, and generated deduplication IDs

## Why

The pinned nightly in #222 exposed these previously untested constructors to Codecov. The migration PR was merged while its Codecov policy checks were still reporting 0% patch coverage and a 1.02% project decrease.

These tests cover the Clippy-touched behavior directly instead of weakening Codecov thresholds. Local LCOV coverage increases from 48.66% to 54.26%.

## Validation

- `cargo test --all-features` (11 unit tests and 7 doctests)
- pinned-nightly Clippy with warnings denied
- pinned-nightly `cargo llvm-cov --all-features --doctests`